### PR TITLE
refact/aws-az: create restricted list of AZs

### DIFF
--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	platDef "github.com/openshift/installer/pkg/types/aws/defaults"
 	"github.com/pkg/errors"
 )
 
@@ -30,6 +31,9 @@ func availabilityZones(ctx context.Context, session *session.Session, region str
 
 	zones := []string{}
 	for _, zone := range resp.AvailabilityZones {
+		if platDef.InvalidAvailabilityZones(region, *zone.ZoneName) {
+			continue
+		}
 		zones = append(zones, *zone.ZoneName)
 	}
 

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -16,6 +16,12 @@ var (
 			// "us-east-1":      {"m6g", "m6gd"},
 		},
 	}
+	defaultZoneExclusionByRegion = map[string][]string{
+		"us-east-1": {
+			// us-east-1e has limitations of Nitro Instances
+			"us-east-1e",
+		},
+	}
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -54,4 +60,24 @@ func InstanceClasses(region string, arch types.Architecture) []string {
 	default:
 		return []string{"m5", "m4"}
 	}
+}
+
+// InvalidAvailabilityZones return a boolean indicating if there's
+// restrictions to use the zoneName on the region.
+func InvalidAvailabilityZones(region, zoneName string) bool {
+	var invalid bool = false
+
+	// No region to be excluded
+	if _, ok := defaultZoneExclusionByRegion[region]; !ok {
+		return invalid
+	}
+
+	// No AZ in current region to be excluded
+	for _, az := range defaultZoneExclusionByRegion[region] {
+		if az == zoneName {
+			return !invalid
+		}
+	}
+
+	return invalid
 }


### PR DESCRIPTION
- Create a restrict list of AZs in a given zone to avoid to be used when provisioning a cluster.
- Bypass AZ `us-east-1e` that has restrictions in newer instances (Nitro, ARMs, etc)

## Tests

- Only zones in "non excluded list" will be created:
![Screenshot from 2021-08-19 22-03-07](https://user-images.githubusercontent.com/3216894/130162930-00636ed3-5c41-4dd3-860e-809ec4274fb0.png)

- AWS Instances in `us-east-1` now can use by default Nitro Instances without of blocking of the zone `us-east-1e`:

![Screenshot from 2021-08-19 22-20-16](https://user-images.githubusercontent.com/3216894/130164142-43821e42-ccae-4c33-be75-3b2962335971.png)

- Differences between [m4](https://instances.vantage.sh/?cost_duration=monthly&compare_on=true&selected=m4.large,m5.large):

![Screenshot from 2021-08-19 22-28-36](https://user-images.githubusercontent.com/3216894/130164764-5b201e9a-2de5-4e53-9cac-f807b706e900.png)

![Screenshot from 2021-08-19 22-28-47](https://user-images.githubusercontent.com/3216894/130164768-5e525e7b-a9f0-4c07-9db8-e4712b1bb90c.png)
