### PR TITLE
refact: choose preferred instance when min HA is satisfied

### DIFF
--- a/pkg/asset/machines/aws/instance_types.go
+++ b/pkg/asset/machines/aws/instance_types.go
@@ -29,6 +29,11 @@ func PreferredInstanceType(ctx context.Context, meta *awsconfig.Metadata, types 
 		return types[0], err
 	}
 
+	// priority instance is available in enough zones to run in full HA
+	if len(found[types[0]]) >= 3 {
+		return types[0], err
+	}
+
 	for _, t := range types {
 		if found[t].HasAll(zones...) {
 			return t, nil

--- a/pkg/asset/machines/aws/instance_types.go
+++ b/pkg/asset/machines/aws/instance_types.go
@@ -29,7 +29,7 @@ func PreferredInstanceType(ctx context.Context, meta *awsconfig.Metadata, types 
 		return types[0], err
 	}
 
-	// priority instance is available in enough zones to run in full HA
+	// preferred type is available in enough zones to run the full HA
 	if len(found[types[0]]) >= 3 {
 		return types[0], err
 	}


### PR DESCRIPTION
Choose preferred [instanceType](https://github.com/openshift/installer/blob/master/pkg/types/aws/defaults/platform.go#L55) when N zone satisfy the HA.

Then, force to ignore the election of less precedence of preferred types when is not available in one AZ. See alternative: https://github.com/mtulio/installer/pull/1

- Subnets created (`1e`) was automatically removed:

![Screenshot from 2021-08-20 00-06-07](https://user-images.githubusercontent.com/3216894/130172984-647032cc-b0a7-4846-9277-611e3c6123b5.png)

![Screenshot from 2021-08-20 00-17-44](https://user-images.githubusercontent.com/3216894/130173823-9dcb4a2d-9d5d-494b-ac47-2bf3f66e78e5.png)
