### PR TITLE
aws-type: changing preferred instance type to m6i, instead of m5/m4

### DIFF
--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -52,6 +52,6 @@ func InstanceClasses(region string, arch types.Architecture) []string {
 	case types.ArchitectureARM64:
 		return []string{"m6g"}
 	default:
-		return []string{"m5", "m4"}
+		return []string{"m6i", "m5"}
 	}
 }


### PR DESCRIPTION
That changes is part of WIP lab to validate gp3 volume type in newest instance types (m5 and m6i).

AWS recently launched the [instance m6i](https://aws.amazon.com/blogs/aws/new-amazon-ec2-m6i-instances-powered-by-the-latest-generation-intel-xeon-scalable-processors/), new generation of Nitro instance for general purpose (m5).

ATM the instance is available in a few regions, but the fallback will work well for m5 that was tested on PR #5162 (1)

I successful launched the m6i, but some changes may need to be done. I will keep the list:
- [ ] change bootstrap instance type (how to use m5 as fallback?)
- [ ] update the docs?
- [ ] e2e tests?

1) Regions that has m6i available
```
Out[17]: 
            region  count(m6i.large)  count(m5.large)  count(m6i<>m5)
0       af-south-1                 0                3              -3
1        ap-east-1                 0                3              -3
2   ap-northeast-1                 2                3              -1
3   ap-northeast-2                 0                4              -4
4       ap-south-1                 0                3              -3
5   ap-southeast-1                 2                3              -1
6   ap-southeast-2                 0                3              -3
7     ca-central-1                 0                3              -3
8     eu-central-1                 2                3              -1
9       eu-north-1                 0                3              -3
10      eu-south-1                 0                3              -3
11       eu-west-1                 3                3               0
12       eu-west-2                 0                3              -3
13       eu-west-3                 0                3              -3
14      me-south-1                 0                3              -3
15       sa-east-1                 0                3              -3
16       us-east-1                 5                5               0
17       us-east-2                 3                3               0
18       us-west-1                 2                2               0
19       us-west-2                 4                4               0
```
2) Successful provisioning changing preferred instance.

![Screenshot from 2021-08-24 15-36-43](https://user-images.githubusercontent.com/3216894/130671361-1ea609f8-dcfb-4e92-bfd9-edee61b71c9f.png)

