### PR TITLE
WIP LAB | aws-ebs: supporting extra volume with type gp3 and io2 on masters

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -8,7 +8,7 @@ locals {
   description = "Created By OpenShift Installer"
 
   public_endpoints = var.aws_publish_strategy == "External" ? true : false
-  volume_type      = "gp2"
+  volume_type      = "gp3"
   volume_size      = 30
   volume_iops      = local.volume_type == "io1" ? 100 : 0
 }

--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -163,6 +163,16 @@ resource "aws_instance" "master" {
     kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
   }
 
+  // TODO(mtulio): support ebsBlockDevices - get same values of root_block_device
+  ebs_block_device {
+    device_name = "/dev/xvdb"
+    volume_type = var.root_volume_type
+    volume_size = var.root_volume_size
+    iops        = var.root_volume_type == "io1" ? var.root_volume_iops : 0
+    encrypted   = var.root_volume_encrypted
+    kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
+  }
+
   volume_tags = merge(
     {
       "Name" = "${var.cluster_id}-master-${count.index}-vol"

--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -163,15 +163,20 @@ resource "aws_instance" "master" {
     kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
   }
 
-  // TODO(mtulio): support ebsBlockDevices - get same values of root_block_device
-  ebs_block_device {
-    device_name = "/dev/xvdb"
-    volume_type = var.root_volume_type
-    volume_size = var.root_volume_size
-    iops        = var.root_volume_type == "io1" ? var.root_volume_iops : 0
-    encrypted   = var.root_volume_encrypted
-    kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
-  }
+  // TODO(mtulio): steps to support ebsBlockDevices
+  #ebs_block_device = var.ebs_block_devices
+  #ephemeral_block_devices = var.ephemeral_block_devices
+
+  // Uncomment to create a second block with same values of root_block_device
+  #ebs_block_device [{
+  #  device_name = "/dev/xvdb"
+  #  volume_type = var.root_volume_type
+  #  volume_size = var.root_volume_size
+  #  iops        = var.root_volume_type == "io1" ? var.root_volume_iops : 0
+  #  encrypted   = var.root_volume_encrypted
+  #  kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
+  #}]
+
 
   volume_tags = merge(
     {

--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -133,6 +133,7 @@ resource "aws_instance" "master" {
   iam_instance_profile = aws_iam_instance_profile.master.name
   instance_type        = var.instance_type
   user_data            = var.user_data_ign
+  monitoring           = var.monitoring
 
   network_interface {
     network_interface_id = aws_network_interface.master[count.index].id
@@ -153,6 +154,7 @@ resource "aws_instance" "master" {
     var.tags,
   )
 
+  ebs_optimized = var.ebs_optimized
   root_block_device {
     volume_type = var.root_volume_type
     volume_size = var.root_volume_size

--- a/data/data/aws/cluster/master/variables.tf
+++ b/data/data/aws/cluster/master/variables.tf
@@ -95,3 +95,15 @@ variable "iam_role_name" {
   type = string
   description = "The name of the existing role to use for the instance profile"
 }
+
+variable "monitoring" {
+  type        = string
+  default     = "true"
+  description = "AWS Detailed monitoring."
+}
+
+variable "ebs_optimized" {
+  type        = bool
+  default     = true
+  description = "AWS EBS Optimized."
+}

--- a/data/data/aws/cluster/master/variables.tf
+++ b/data/data/aws/cluster/master/variables.tf
@@ -60,6 +60,20 @@ variable "root_volume_kms_key_id" {
   description = "The KMS key id that should be used tpo encrypt the root block device."
 }
 
+# https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/latest#input_ebs_block_device
+variable "ebs_block_devices" {
+  type        = list(map(string))
+  default     = []
+  description =  EBS Block Device list - non-root
+}
+
+# https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/latest#input_ephemeral_block_device
+variable "ephemeral_block_devices" {
+  type        = list(map(string))
+  default     = []
+  description =  Instance Block Device list - non-root
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -127,6 +127,51 @@ spec:
                           items:
                             type: string
                           type: array
+                        # TODO(mtulio): change to list of volumes (ebsBlockDevices)
+                        ebsBlockDevices:
+                          description: Extra block devices.
+                          items:
+                            description: EC2RootVolume defines the root volume for EC2
+                              instances in the machine pool.
+                            properties:
+                              iops:
+                                description: IOPS defines the amount of provisioned
+                                  IOPS. This is only valid for type io1.
+                                minimum: 0
+                                type: integer
+                              kmsKeyARN:
+                                description: The KMS key that will be used to encrypt
+                                  the EBS volume. If no key is provided the default
+                                  KMS key for the account will be used. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+                                type: string
+                              size:
+                                description: Size defines the size of the volume in
+                                  gibibytes (GiB).
+                                minimum: 0
+                                type: integer
+                              type:
+                                description: Type defines the type of the volume.
+                                type: string
+                              deviceName:
+                                description: Block device name
+                                type: string
+                              # label:
+                              #   description: Label name
+                              #   type: string
+                              # mountPath:
+                              #   description: Mount path
+                              #   type: string
+                              # mountPath:
+                              #   description: Mount path
+                              #   type: string
+                            required:
+                            - deviceName
+                            # - label
+                            # - mountPath
+                            - size
+                            - type
+                            type: object
+                          type: array
                       type: object
                     azure:
                       description: Azure is the configuration used when installing

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -128,7 +128,7 @@ spec:
                             type: string
                           type: array
                         # TODO(mtulio): change to list of volumes (ebsBlockDevices)
-                        ebsBlockDevices:
+                        blockDevices:
                           description: Extra block devices.
                           items:
                             description: EC2RootVolume defines the root volume for EC2
@@ -150,8 +150,10 @@ spec:
                                 minimum: 0
                                 type: integer
                               type:
-                                description: Type defines the type of the volume.
+                                description: Type defines the type of the volume (EBS or Ephemeral).
                                 type: string
+                              # TODO check correct names: deviceName (OS) &| blockName (VIRT)
+                              # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
                               deviceName:
                                 description: Block device name
                                 type: string

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -39,6 +39,8 @@ type config struct {
 	BootstrapIgnitionStub   string            `json:"aws_bootstrap_stub_ignition"`
 	MasterIAMRoleName       string            `json:"aws_master_iam_role_name,omitempty"`
 	WorkerIAMRoleName       string            `json:"aws_worker_iam_role_name,omitempty"`
+	// TODO(mtulio) support for additional devices (ebsBlockDevices)
+	// MasterEBSBlockDevice    []map[string]string `json:"aws_master_ebs_block_devices,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -113,6 +115,34 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	if *rootVolume.EBS.VolumeType == "io1" && rootVolume.EBS.Iops == nil {
 		return nil, errors.New("EBS IOPS must be configured for the io1 root volume")
 	}
+
+	if len(masterConfig.BlockDevices) > 2 {
+		return nil, errors.New("We does not support more than two volumes")
+	}
+
+	// TODO(mtulio) : add support to ebsBlockDevices
+	// if len(masterConfig.BlockDevices) > 1 {
+	// 	// TODO (mtulio) support more than one extra vols
+	// 	secondVolume := masterConfig.BlockDevices[1]
+	// 	if secondVolume.EBS == nil {
+	// 		return nil, errors.New("EBS information must be configured for the block device")
+	// 	}
+	// 	if secondVolume.EBS.VolumeType == nil {
+	// 		return nil, errors.New("EBS volume type must be configured for the block device")
+	// 	}
+
+	// 	if secondVolume.EBS.VolumeSize == nil {
+	// 		return nil, errors.New("EBS volume size must be configured for the block device")
+	// 	}
+
+	// 	if secondVolume.EBS.DeviceName == nil {
+	// 		return nil, errors.New("EBS device name must be configured for the block device non-root")
+	// 	}
+
+	// 	if *secondVolume.EBS.VolumeType == "io1" && secondVolume.EBS.Iops == nil {
+	// 		return nil, errors.New("EBS IOPS must be configured for the io1 root volume")
+	// 	}
+	// }
 
 	instanceClass := defaults.InstanceClass(masterConfig.Placement.Region, sources.Architecture)
 

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -52,6 +52,6 @@ func InstanceClasses(region string, arch types.Architecture) []string {
 	case types.ArchitectureARM64:
 		return []string{"m6g"}
 	default:
-		return []string{"m5", "m4"}
+		return []string{"m6i", "m5"}
 	}
 }

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -25,6 +25,11 @@ type MachinePool struct {
 	// +optional
 	EC2RootVolume `json:"rootVolume"`
 
+	// EBSBlockDevices defines the additional volumes for EC2 instances in the machine pool.
+	//
+	// +optional
+	EBSBlockDevices `json:"ebsBlockDevices"`
+
 	// IAMRole is the name of the IAM Role to use for the instance profile of the machine.
 	// Leave unset to have the installer create the IAM Role on your behalf.
 	// +optional
@@ -90,3 +95,30 @@ type EC2RootVolume struct {
 	// +optional
 	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }
+
+// EC2RootVolume defines the storage for an ec2 instance.
+type EBSBlockDevice struct {
+	DeviceName int `json:"deviceName"`
+	// IOPS defines the amount of provisioned IOPS. This is only valid
+	// for type io1.
+	//
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	IOPS int `json:"iops"`
+
+	// Size defines the size of the volume in gibibytes (GiB).
+	//
+	// +kubebuilder:validation:Minimum=0
+	Size int `json:"size"`
+
+	// Type defines the type of the volume.
+	Type string `json:"type"`
+
+	// The KMS key that will be used to encrypt the EBS volume.
+	// If no key is provided the default KMS key for the account will be used.
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+	// +optional
+	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
+}
+
+type EBSBlockDevices []EBSBlockDevice

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -113089,8 +113089,14 @@ const (
 	// VolumeTypeIo1 is a VolumeType enum value
 	VolumeTypeIo1 = "io1"
 
+	// VolumeTypeIo2 is a VolumeType enum value
+	VolumeTypeIo2 = "io2"
+
 	// VolumeTypeGp2 is a VolumeType enum value
 	VolumeTypeGp2 = "gp2"
+
+	// VolumeTypeGp3 is a VolumeType enum value
+	VolumeTypeGp3 = "gp3"
 
 	// VolumeTypeSc1 is a VolumeType enum value
 	VolumeTypeSc1 = "sc1"

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_instance.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_instance.go
@@ -395,7 +395,9 @@ func resourceAwsInstance() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								ec2.VolumeTypeStandard,
 								ec2.VolumeTypeIo1,
+								ec2.VolumeTypeIo2,
 								ec2.VolumeTypeGp2,
+								ec2.VolumeTypeGp3,
 								ec2.VolumeTypeSc1,
 								ec2.VolumeTypeSt1,
 							}, false),
@@ -506,7 +508,9 @@ func resourceAwsInstance() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								ec2.VolumeTypeStandard,
 								ec2.VolumeTypeIo1,
+								ec2.VolumeTypeIo2,
 								ec2.VolumeTypeGp2,
+								ec2.VolumeTypeGp3,
 								ec2.VolumeTypeSc1,
 								ec2.VolumeTypeSt1,
 							}, false),

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/validators.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/validators.go
@@ -1038,7 +1038,9 @@ func validateAwsEcsPlacementStrategy(stratType, stratField string) error {
 func validateAwsEmrEbsVolumeType() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
 		"gp2",
+		"gp3",
 		"io1",
+		"io2",
 		"standard",
 		"st1",
 	}, false)


### PR DESCRIPTION
- support gp3 and IO2 volumes types on Terraform provider (tmp code, need to bump vendor)
- force bootstrap to use gp3 (available in all regions)
- support extra EBS volumes when provisioning instance (master only)
- enable EBS Optimized when provisioning instance (master only)
- enable detailed monitoring when provisioning instance (master only)

References from providers:
- [Terraform - ebsBlock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#ebs_block_device)
- [Terraform - ephemeral block devices](https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/latest#input_ephemeral_block_device)
- [Terraform - block devices attributes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#ebs-ephemeral-and-root-block-devices)
- [AWS block device mapping](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html)