### PR TITLE
introduce edge machinepool for AWS Local Zone

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -98,7 +98,7 @@ spec:
                 name:
                   description: Name is the name of the machine pool. For the control
                     plane machine pool, the name will always be "master". For the
-                    compute machine pools, the only valid name is "worker".
+                    compute machine pools, the valid names are "worker" and "edge".
                   type: string
                 platform:
                   description: Platform is configuration for machine pool specific
@@ -741,8 +741,8 @@ spec:
                 type: string
               name:
                 description: Name is the name of the machine pool. For the control
-                  plane machine pool, the name will always be "master". For the compute
-                  machine pools, the only valid name is "worker".
+                  plane machine pool, the name will always be "master". For the
+                    compute machine pools, the valid names are "worker" and "edge".
                 type: string
               platform:
                 description: Platform is configuration for machine pool specific to

--- a/docs/user/aws/install_existing_vpc_local-zones.md
+++ b/docs/user/aws/install_existing_vpc_local-zones.md
@@ -1,0 +1,404 @@
+# Cluster Installation in existing VPC with Local Zones subnet
+
+The steps below describe how to install a cluster in existing VPC with AWS Local Zones subnets using Edge Machine Pool, introduced in 4.12.
+
+The Edge Machine Pool was created to create a pool of workers running in the AWS Local Zones locations. This pool differs from the default compute pool on these items - Edge workers should not run normal cluster workloads:
+- The resources in AWS Local Zones are more expensive than the normal availability zones
+- The latency between application and end-users is lower in Local Zones and may vary for each location. So it will impact if some workloads like routers are mixed in the normal availability zones due to the unbalanced latency
+- Network Load Balancers do not support subnets in the Local Zones
+- The total time to connect to the applications running in Local Zones from the end-users close to the metropolitan region running the workload, is almost 10x faster than the parent region.
+
+Table of Contents:
+
+- [Pre-Requisites](#pre-requisites)
+- [Create the Network stack](#create-network)
+    - [Create the VPC](#create-network-vpc)
+    - [Create the Local Zone subnet](#create-network-subnet)
+        - [Opt-in zone group](#create-network-subnet-optin)
+            - [Opt-in zone group using AWS CLI](#create-network-subnet-optin-cli)
+            - [Opt-in zone group using AWS Console](#create-network-subnet-optin-console)
+        - [Create the Local Zone Subnet](#create-network-subnet-res)
+            - [Create the Local Zone Subnet using AWS CloudFormation](#create-network-subnet-res-cfn)
+            - [Create the Local Zone Subnet using AWS CLI](#create-network-subnet-res-cli)
+            - [Create the Local Zone Subnet using AWS Console](#create-network-subnet-res-console)
+- [Install](#install-cluster)
+    - [Create the install-config.yaml](#create-config)
+    - [Setting up the Edge Machine Pool](#create-config-edge-pool")
+        - [Example edge pool created without customization](#create-config-edge-pool)
+        - [Example edge pool with custom Instance type](#reate-config-edge-pool-example-ec2)
+        - [Example edge pool with custom EBS type](#create-config-edge-pool-example-ebs)
+    - [Create the cluster](#create-cluster-run)
+- [Uninstall](#uninstall)
+    - [Destroy the cluster](#uninstall-destroy-cluster)
+    - [Destroy the Local Zone subnet](#uninstall-destroy-subnet)
+    - [Destroy the VPC](#uninstall-destroy-vpc)
+
+___
+
+To install a cluster in existing VPC with Local Zone subnets, you should provision the network resources and then add the subnet IDs to the `install-config.yaml`.
+
+## Pre-requisites <a name="pre-requisites"></a>
+
+- [AWS Command Line Interface](aws-cli)
+- [openshift-install >= 4.12](openshift-install)
+- environment variables exported
+
+```bash
+export CLUSTER_NAME="ipi-localzone"
+
+# AWS Region and extra Local Zone group Information
+export AWS_REGION="us-west-2"
+export ZONE_GROUP="us-west-2-lax-1"
+export ZONE_NAME="us-west-2-lax-1a"
+
+# VPC Information
+export VPC_CIDR="10.0.0.0/16"
+export VPC_SUBNETS_BITS="10"
+export VPC_SUBNETS_COUNT="3"
+
+# Local Zone Subnet information
+export SUBNET_CIDR="10.0.192.0/22"
+export SUBNET_NAME="${CLUSTER_NAME}-public-usw2-lax-1a"
+```
+
+## Create the Network Stack <a name="create-network"></a>
+
+### Create the VPC <a name="create-network-vpc"></a>
+
+The steps to install a cluster in existing VPC are [detailed on the official documentation](aws-install-vpc). You can alternatively use [the CloudFormation templates to create the Network resources](aws-install-cloudformation), which will be used in this document.
+
+- Create the Stack
+
+```bash
+INSTALER_URL="file:///home/mtulio/go/src/github.com/mtulio/installer"
+#INSTALER_URL="https://raw.githubusercontent.com/mtulio/installer/master"
+TPL_URL="${INSTALER_URL}/upi/aws/cloudformation/01_vpc.yaml"
+
+aws cloudformation create-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${CLUSTER_NAME}-vpc \
+    --template-body ${TPL_URL} \
+    --parameters \
+        ParameterKey=VpcCidr,ParameterValue=${VPC_CIDR} \
+        ParameterKey=SubnetBits,ParameterValue=${VPC_SUBNETS_BITS} \
+        ParameterKey=AvailabilityZoneCount,ParameterValue=${VPC_SUBNETS_COUNT}
+```
+
+Check the Stack:
+
+```bash
+aws cloudformation describe-stacks \
+    --region ${AWS_REGION} \
+    --stack-name ${CLUSTER_NAME}-vpc 
+```
+
+Extract the subnets IDs to the environment variable list `SUBNETS`:
+
+```bash
+mapfile -t SUBNETS < <(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc \
+  | jq -r '.Stacks[0].Outputs[0].OutputValue' | tr ',' '\n')
+mapfile -t -O "${#SUBNETS[@]}" SUBNETS < <(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc  \
+  | jq -r '.Stacks[0].Outputs[1].OutputValue' | tr ',' '\n')
+```
+
+Export the VPC ID:
+
+```bash
+export VPC_ID=$(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="VpcId").OutputValue' )
+```
+
+Export the Public Route Table ID:
+
+```bash
+export PUBLIC_RTB_ID=$(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicRouteTableId").OutputValue' )
+```
+
+Make sure all variables were set:
+
+```bash
+echo "SUBNETS=${SUBNETS[*]}
+VPC_ID=${VPC_ID}
+PUBLIC_RTB_ID=${PUBLIC_RTB_ID}"
+```
+
+### Create the Local Zone subnet <a name="create-network-subnet"></a>
+
+The following actions are required to create subnets in Local Zones:
+- choose the zone group to be enabled
+- opt-in the zone group
+
+#### Opt-in Zone groups <a name="create-network-subnet-optin"></a>
+
+##### Steps to opt-in Zone Groups using AWS CLI <a name="create-network-subnet-optin-cli"></a>
+
+```bash
+aws ec2 modify-availability-zone-group \
+    --region ${AWS_REGION} \
+    --group-name ${ZONE_GROUP} \
+    --opt-in-status opted-in
+```
+
+##### Steps to opt-in Zone Groups using AWS Console <a name="create-network-subnet-optin-console"></a>
+
+TBD/Is it needed?
+
+#### Creating the Subnet <a name="create-network-subnet-res"></a>
+
+##### Creating the subnet using AWS CloudFormation <a name="create-network-subnet-res-cfn"></a>
+
+- Create the Stack for Local Zone subnet `us-west-2-lax-1a`
+
+```bash
+INSTALER_URL="file:///home/mtulio/go/src/github.com/mtulio/installer"
+#INSTALER_URL="https://raw.githubusercontent.com/mtulio/installer/master"
+TPL_URL="${INSTALER_URL}/upi/aws/cloudformation/01.99_net_local-zone.yaml"
+
+aws cloudformation create-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${SUBNET_NAME} \
+    --template-body ${TPL_URL} \
+    --parameters \
+        ParameterKey=VpcId,ParameterValue=${VPC_ID} \
+        ParameterKey=ZoneName,ParameterValue=${ZONE_NAME} \
+        ParameterKey=SubnetName,ParameterValue=${SUBNET_NAME} \
+        ParameterKey=PublicSubnetCidr,ParameterValue=${SUBNET_CIDR} \
+        ParameterKey=PublicRouteTableId,ParameterValue=${PUBLIC_RTB_ID}
+```
+
+- Wait for the stack be created `StackStatus=CREATE_COMPLETE`
+
+```bash
+aws cloudformation describe-stacks \
+  --region ${AWS_REGION} \
+  --stack-name ${SUBNET_NAME}
+```
+
+- Export the Local Zone subnet ID
+
+```bash
+export SUBNET_ID=$(aws cloudformation describe-stacks \
+  --region ${AWS_REGION} \
+  --stack-name ${SUBNET_NAME} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicSubnetIds").OutputValue' )
+
+# Append the Local Zone Subnet ID to the Subnet List
+SUBNETS+=(${SUBNET_ID})
+```
+
+- Check the total of subnets. If you choose 3 AZs to be created on the VPC stack, you should have 7 subnets on this list:
+
+```bash
+$ echo ${#SUBNETS[*]}
+7
+```
+
+##### Creating the subnet using AWS CLI <a name="create-network-subnet-res-cli"></a>
+
+TBD/Is it needed?
+
+##### Creating the subnet using AWS Console <a name="create-network-subnet-res-console"></a>
+
+TBD/Is it needed?
+
+## Install the cluster <a name="install-cluster"></a>
+
+To install the cluster in existing VPC with subnets in Local Zones, you should:
+- generate the install-config.yaml, you provide yours
+- add the subnet IDs setting the option `platform.aws.subnets`
+- (option) customize the Edge Machine Pool
+
+### Create the install-config.yaml <a name="create-config"></a>
+
+Create the `install-config.yaml` providing the subnet IDs recently created:
+
+- create the `install-config`
+
+```bash
+$ ./openshift-install-2022091601 create install-config --dir ${CLUSTER_NAME}
+? SSH Public Key /home/user/.ssh/id_rsa.pub
+? Platform aws
+? Region us-west-2
+? Base Domain devcluster.openshift.com
+? Cluster Name ipi-localzone
+? Pull Secret [? for help] **
+INFO Install-Config created in: ipi-localzone     
+```
+
+- Append the subnets to the `platform.aws.subnets`:
+
+```bash
+$ echo "    subnets:"; for SB in ${SUBNETS[*]}; do echo "    - $SB"; done
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+```
+
+### Setting up the Edge Machine Pool <a name="create-config-edge-pool"></a>
+
+Version 4.12 e earlier introduces a new Machine Pool designed for the edge locations.
+The Edge Machine Pool configuration is common between edge locations, but due to the limitation
+of resources (Instance Types and Sizes) of the Local Zone, the default instance type created
+may vary from the traditional worker pool.
+
+The default EBS for Local Zone locations is `gp2`, different than the default worker pool.
+
+The preferred list of instance type follows the same order of worker pools, depending
+on the availability of the location, one of those instances will be chosen*:
+> Note: This list can be updated over the time
+- `m6i.xlarge`
+- `m5.xlarge`
+- `c5d.2xlarge`
+
+The Edge Machine Pool will also create new labels for the Machines to help developers to
+deploy their applications onto those locations. The new labels introduced are:
+    - `node-role.kubernetes.io/edge=''`
+    - `zone_type=local-zone`
+    - `zone_group=<Local Zone Group>`
+
+Finally, the MachineSets created on the Edge Machine Pool have `NoSchedule` taint to avoid the
+normal workloads spread out on those machines, and only user workloads will be allowed to run
+when the tolerations are defined on the pod spec.
+
+By default, the Edge Machine Pools will be created only when AWS Local Zone subnet IDs are added
+to the list of `platform.aws.subnets`.
+
+See below some examples of Edge Machine Pool.
+
+#### Example edge pool created without customization <a name="create-config-edge-pool-example-def"></a>
+
+```yaml
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+metadata:
+  name: ipi-localzone
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+#### Example edge pool with custom Instance type <a name="create-config-edge-pool-example-ec2"></a>
+
+The Instance Type may differ between locations. You should check the AWS Documentation to check availability in the Local Zone that the cluster will run.
+
+`install-config.yaml` example customizing the Instance Type for the Edge Machine Pool:
+
+```yaml
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+metadata:
+  name: ipi-localzone
+compute:
+- name: edge
+  platform:
+    aws:
+      type: m5.4xlarge
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+#### Example edge pool with custom EBS type <a name="create-config-edge-pool-example-ebs"></a>
+
+The EBS Type may differ between locations. You should check the AWS Documentation to check availability in the Local Zone that the cluster will run.
+
+`install-config.yaml` example customizing the EBS Type for the Edge Machine Pool:
+
+```yaml
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+metadata:
+  name: ipi-localzone
+compute:
+- name: edge
+  platform:
+    aws:
+      rootVolume:
+        type: gp3
+        size: 120
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+### Create the cluster <a name="create-cluster-run"></a>
+
+```bash
+./openshift-install create cluster --dir ${CLUSTER_NAME}
+```
+
+### Uninstall the cluster <a name="uninstall"></a>
+
+#### Destroy the cluster <a name="uninstall-destroy-cluster"></a>
+
+```bash
+./openshift-install destroy cluster --dir ${CLUSTER_NAME}
+```
+
+#### Destroy the Local Zone subnets <a name="uninstall-destroy-subnet"></a>
+
+
+```bash
+aws cloudformation delete-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${SUBNET_NAME}
+```
+
+#### Destroy the VPC <a name="uninstall-destroy-vpc"></a>
+
+```bash
+aws cloudformation delete-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${CLUSTER_NAME}-vpc
+```
+
+[openshift-install]: https://docs.openshift.com/container-platform/4.11/installing/index.html
+[aws-cli]: https://aws.amazon.com/cli/
+[aws-install-vpc]: https://docs.openshift.com/container-platform/4.11/installing/installing_aws/installing-aws-vpc.html
+[aws-install-cloudformation]: https://docs.openshift.com/container-platform/4.11/installing/installing_aws/installing-aws-user-infra.html
+[aws-local-zones]: https://aws.amazon.com/about-aws/global-infrastructure/localzones
+[aws-local-zones-features]: https://aws.amazon.com/about-aws/global-infrastructure/localzones/features

--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 	"github.com/pkg/errors"
 )
 
@@ -40,7 +41,7 @@ func availabilityZones(ctx context.Context, session *session.Session, region str
 	}
 	zones := []string{}
 	for _, zone := range azs {
-		if *zone.ZoneType == "availability-zone" {
+		if *zone.ZoneType == awstypes.AvailabilityZoneTypeDefault {
 			zones = append(zones, *zone.ZoneName)
 		}
 	}
@@ -57,17 +58,17 @@ func localZones(ctx context.Context, session *session.Session, region string) ([
 
 	azs, err := describeAvailabilityZones(ctx, session, region)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching availability zones")
+		return nil, errors.Wrap(err, "fetching availability zones type local-zone")
 	}
 	zones := []string{}
 	for _, zone := range azs {
-		if *zone.ZoneType == "local-zone" {
+		if *zone.ZoneType == awstypes.AvailabilityZoneTypeDefault {
 			zones = append(zones, *zone.ZoneName)
 		}
 	}
 
 	if len(zones) == 0 {
-		return nil, errors.Errorf("no available zones type Local in %s", region)
+		return nil, errors.Errorf("no availability zones type local-zone in %s", region)
 	}
 
 	return zones, nil

--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -72,24 +72,3 @@ func localZones(ctx context.Context, session *session.Session, region string) ([
 
 	return zones, nil
 }
-
-// localZones retrieves a list of Local zones for the given parent region.
-func wavelengthZones(ctx context.Context, session *session.Session, region string) ([]string, error) {
-
-	azs, err := describeAvailabilityZones(ctx, session, region)
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching availability zones")
-	}
-	zones := []string{}
-	for _, zone := range azs {
-		if *zone.ZoneType == "wavelength-zone" {
-			zones = append(zones, *zone.ZoneName)
-		}
-	}
-
-	if len(zones) == 0 {
-		return nil, errors.Errorf("no available zones type Wavelength in %s", region)
-	}
-
-	return zones, nil
-}

--- a/pkg/asset/installconfig/aws/metadata.go
+++ b/pkg/asset/installconfig/aws/metadata.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -88,8 +87,6 @@ func (m *Metadata) EdgeSubnets(ctx context.Context) (map[string]Subnet, error) {
 		return nil, err
 	}
 
-	fmt.Println(">>>>>>>>>>>")
-	fmt.Println(m.edgeSubnets)
 	return m.edgeSubnets, nil
 }
 
@@ -137,17 +134,11 @@ func (m *Metadata) populateSubnets(ctx context.Context) error {
 		return err
 	}
 
-	// m.vpc, m.privateSubnets, m.publicSubnets, err = subnets(ctx, session, m.Region, m.Subnets)
 	sb, err := subnets(ctx, session, m.Region, m.Subnets)
 	m.vpc = sb.VPC
 	m.privateSubnets = sb.Private
 	m.publicSubnets = sb.Public
 	m.edgeSubnets = sb.Edge
-	fmt.Println("populateSubnets() > ")
-	fmt.Println(m)
-	fmt.Printf("\n> public: %v", m.publicSubnets)
-	fmt.Printf("\n> private: %v", m.privateSubnets)
-	fmt.Printf("\n> edge: %v\n", m.edgeSubnets)
 	return err
 }
 

--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -142,7 +143,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		meta.ZoneType = *availabilityZones[meta.Zone].ZoneType
 
 		// TODO: Add wavelength-zone when CarrierGateway will be supported on MachineSpec
-		if meta.ZoneType == "local-zone" {
+		if meta.ZoneType == awstypes.AvailabilityZoneTypeLocal {
 			subnets.Edge[id] = meta
 		} else if isPublic {
 			subnets.Public[id] = meta

--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -12,6 +12,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type Subnets struct {
+	Public  map[string]Subnet
+	Private map[string]Subnet
+	Edge    map[string]Subnet
+	VPC     string
+}
+
 // Subnet holds metadata for a subnet.
 type Subnet struct {
 	// ARN is the subnet's Amazon Resource Name.
@@ -22,13 +29,33 @@ type Subnet struct {
 
 	// CIDR is the subnet's CIDR block.
 	CIDR string
+
+	// ZoneType is the type of subnet's availability zone.
+	ZoneType string
+
+	// Public is the flag to define the subnet public.
+	Public bool
 }
 
 // subnets retrieves metadata for the given subnet(s).
-func subnets(ctx context.Context, session *session.Session, region string, ids []string) (vpc string, private map[string]Subnet, public map[string]Subnet, err error) {
+func subnets(ctx context.Context, session *session.Session, region string, ids []string) (subnets Subnets, err error) {
+	zoneNames := make([]*string, len(ids))
+	availabilityZones := make(map[string]*ec2.AvailabilityZone, len(ids))
+
 	metas := make(map[string]Subnet, len(ids))
-	private = map[string]Subnet{}
-	public = map[string]Subnet{}
+	// private = map[string]Subnet{}
+	// public = map[string]Subnet{}
+	// edge = map[string]Subnet{}
+	// Public:  make(map[string]Subnet, len(ids)),
+	// Private: make(map[string]Subnet, len(ids)),
+	// Edge:    make(map[string]Subnet, len(ids)),
+	subnets = Subnets{
+		VPC:     "",
+		Public:  make(map[string]Subnet, len(ids)),
+		Private: make(map[string]Subnet, len(ids)),
+		Edge:    make(map[string]Subnet, len(ids)),
+	}
+
 	var vpcFromSubnet string
 	client := ec2.New(session, aws.NewConfig().WithRegion(region))
 
@@ -41,34 +68,41 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		&ec2.DescribeSubnetsInput{SubnetIds: idPointers},
 	)
 	if err != nil {
-		return vpc, nil, nil, errors.Wrap(err, "describing subnets")
+		return subnets, errors.Wrap(err, "describing subnets")
 	}
+	if err != nil {
+		return subnets, errors.Wrap(err, "describing subnets")
+	}
+
 	for _, subnet := range results.Subnets {
 		if subnet.SubnetId == nil {
 			continue
 		}
 		if subnet.SubnetArn == nil {
-			return vpc, nil, nil, errors.Errorf("%s has no ARN", *subnet.SubnetId)
+			return subnets, errors.Errorf("%s has no ARN", *subnet.SubnetId)
 		}
 		if subnet.VpcId == nil {
-			return vpc, nil, nil, errors.Errorf("%s has no VPC", *subnet.SubnetId)
+			return subnets, errors.Errorf("%s has no VPC", *subnet.SubnetId)
 		}
 		if subnet.AvailabilityZone == nil {
-			return vpc, nil, nil, errors.Errorf("%s has no availability zone", *subnet.SubnetId)
+			return subnets, errors.Errorf("%s has no availability zone", *subnet.SubnetId)
 		}
 
-		if vpc == "" {
-			vpc = *subnet.VpcId
+		if subnets.VPC == "" {
+			subnets.VPC = *subnet.VpcId
+			// vpc = *subnet.VpcId
 			vpcFromSubnet = *subnet.SubnetId
-		} else if *subnet.VpcId != vpc {
-			return vpc, nil, nil, errors.Errorf("all subnets must belong to the same VPC: %s is from %s, but %s is from %s", *subnet.SubnetId, *subnet.VpcId, vpcFromSubnet, vpc)
+		} else if *subnet.VpcId != subnets.VPC {
+			return subnets, errors.Errorf("all subnets must belong to the same VPC: %s is from %s, but %s is from %s", *subnet.SubnetId, *subnet.VpcId, vpcFromSubnet, subnets.VPC)
 		}
 
 		metas[*subnet.SubnetId] = Subnet{
-			ARN:  *subnet.SubnetArn,
-			Zone: *subnet.AvailabilityZone,
-			CIDR: *subnet.CidrBlock,
+			ARN:    *subnet.SubnetArn,
+			Zone:   *subnet.AvailabilityZone,
+			CIDR:   *subnet.CidrBlock,
+			Public: false,
 		}
+		zoneNames = append(zoneNames, subnet.AvailabilityZone)
 	}
 
 	var routeTables []*ec2.RouteTable
@@ -77,7 +111,7 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		&ec2.DescribeRouteTablesInput{
 			Filters: []*ec2.Filter{{
 				Name:   aws.String("vpc-id"),
-				Values: []*string{aws.String(vpc)},
+				Values: []*string{aws.String(subnets.VPC)},
 			}},
 		},
 		func(results *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
@@ -86,26 +120,48 @@ func subnets(ctx context.Context, session *session.Session, region string, ids [
 		},
 	)
 	if err != nil {
-		return vpc, nil, nil, errors.Wrap(err, "describing route tables")
+		return subnets, errors.Wrap(err, "describing route tables")
+	}
+
+	azs, err := client.DescribeAvailabilityZonesWithContext(
+		ctx,
+		&ec2.DescribeAvailabilityZonesInput{
+			ZoneNames: zoneNames,
+		},
+	)
+	if err != nil {
+		return subnets, errors.Wrap(err, "describing availability zones")
+	}
+	for _, az := range azs.AvailabilityZones {
+		availabilityZones[*az.ZoneName] = az
 	}
 
 	for _, id := range ids {
 		meta, ok := metas[id]
 		if !ok {
-			return vpc, nil, nil, errors.Errorf("failed to find %s", id)
+			return subnets, errors.Errorf("failed to find %s", id)
 		}
 		isPublic, err := isSubnetPublic(routeTables, id)
 		if err != nil {
-			return vpc, nil, nil, err
+			return subnets, err
 		}
-		if isPublic {
-			public[id] = meta
+		meta.Public = isPublic
+		meta.ZoneType = *availabilityZones[meta.Zone].ZoneType
+		fmt.Println(meta.ZoneType)
+		// TODO: Add wavelength-zone when CarrierGateway will be supported on MachineSpec
+		if meta.ZoneType == "local-zone" {
+			// edge[id] = meta
+			subnets.Edge[id] = meta
+		} else if isPublic {
+			// public[id] = meta
+			subnets.Public[id] = meta
 		} else {
-			private[id] = meta
+			// private[id] = meta
+			subnets.Private[id] = meta
 		}
 	}
 
-	return vpc, private, public, nil
+	return subnets, nil
 }
 
 // https://github.com/kubernetes/kubernetes/blob/9f036cd43d35a9c41d7ac4ca82398a6d0bef957b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L3376-L3419

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -180,7 +180,7 @@ func validateMachinePool(ctx context.Context, meta *Metadata, fldPath *field.Pat
 		availableZones := sets.String{}
 		if len(platform.Subnets) > 0 {
 			subnets, err := meta.PrivateSubnets(ctx)
-			if poolName == "edge" {
+			if poolName == types.InstallConfigPoolNameEdge {
 				subnets, err = meta.EdgeSubnets(ctx)
 			}
 			if err != nil {

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -176,44 +176,31 @@ func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, s
 
 func validateMachinePool(ctx context.Context, meta *Metadata, fldPath *field.Path, platform *awstypes.Platform, pool *awstypes.MachinePool, req resourceRequirements, poolName string) field.ErrorList {
 	allErrs := field.ErrorList{}
-	fmt.Println("DEBUG 1")
-	fmt.Println(poolName)
 	if len(pool.Zones) > 0 {
 		availableZones := sets.String{}
-		fmt.Println("DEBUG 2")
 		if len(platform.Subnets) > 0 {
 			subnets, err := meta.PrivateSubnets(ctx)
 			if poolName == "edge" {
 				subnets, err = meta.EdgeSubnets(ctx)
 			}
-			fmt.Println(subnets)
 			if err != nil {
 				return append(allErrs, field.InternalError(fldPath, err))
 			}
-			fmt.Println("DEBUG 2.5")
 			for _, subnet := range subnets {
 				availableZones.Insert(subnet.Zone)
 			}
 		} else {
-			fmt.Println("DEBUG 3")
 			allzones, err := meta.AvailabilityZones(ctx)
-			fmt.Println(allzones)
 			if err != nil {
 				return append(allErrs, field.InternalError(fldPath, err))
 			}
 			availableZones.Insert(allzones...)
 		}
-		fmt.Println("DEBUG 4")
-		fmt.Println(meta)
-		fmt.Println(pool.Zones)
-		fmt.Println(availableZones)
 		if diff := sets.NewString(pool.Zones...).Difference(availableZones); diff.Len() > 0 {
 			errMsg := fmt.Sprintf("No subnets provided for zones %s", diff.List())
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("zones"), pool.Zones, errMsg))
 		}
-		fmt.Println("DEBUG 4.3")
 	}
-	fmt.Println("DEBUG 5")
 	if pool.InstanceType != "" {
 		instanceTypes, err := meta.InstanceTypes(ctx)
 		if err != nil {

--- a/pkg/asset/machines/aws/instance_types.go
+++ b/pkg/asset/machines/aws/instance_types.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -35,7 +36,7 @@ func PreferredInstanceType(ctx context.Context, meta *awsconfig.Metadata, types 
 		}
 	}
 
-	return types[0], errors.New("no instance type found for the zone constraint")
+	return types[0], errors.New(fmt.Sprintf("no instance type found%v for the zone constraint%v", types, zones))
 }
 
 // FilterZonesBasedOnInstanceType return a filtered list of zones where the particular instance type is available. This is mainly necessary for ARM, where the instance type m6g is not

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -16,6 +16,21 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
+type machineProviderInput struct {
+	clusterID      string
+	region         string
+	subnet         string
+	instanceType   string
+	osImage        string
+	zone           string
+	role           string
+	userDataSecret string
+	root           *aws.EC2RootVolume
+	imds           aws.EC2Metadata
+	userTags       map[string]string
+	privateSubnet  bool
+}
+
 // Machines returns a list of machines for a machinepool.
 func Machines(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]machineapi.Machine, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {
@@ -34,19 +49,21 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 		if len(subnets) > 0 && !ok {
 			return nil, errors.Errorf("no subnet for zone %s", zone)
 		}
-		provider, err := provider(
-			clusterID,
-			region,
-			subnet,
-			mpool.InstanceType,
-			&mpool.EC2RootVolume,
-			mpool.EC2Metadata,
-			mpool.AMIID,
-			zone,
-			role,
-			userDataSecret,
-			userTags,
-		)
+		machineProviderInput := machineProviderInput{
+			clusterID:      clusterID,
+			region:         region,
+			subnet:         subnet,
+			instanceType:   mpool.InstanceType,
+			osImage:        mpool.AMIID,
+			zone:           zone,
+			role:           role,
+			userDataSecret: userDataSecret,
+			root:           &mpool.EC2RootVolume,
+			imds:           mpool.EC2Metadata,
+			userTags:       userTags,
+			privateSubnet:  false,
+		}
+		provider, err := provider(&machineProviderInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -78,8 +95,9 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 	return machines, nil
 }
 
-func provider(clusterID string, region string, subnet string, instanceType string, root *aws.EC2RootVolume, imds aws.EC2Metadata, osImage string, zone, role, userDataSecret string, userTags map[string]string) (*machineapi.AWSMachineProviderConfig, error) {
-	tags, err := tagsFromUserTags(clusterID, userTags)
+//func provider(clusterID string, region string, subnet string, instanceType string, root *aws.EC2RootVolume, imds aws.EC2Metadata, osImage string, zone, role, userDataSecret string, userTags map[string]string, privateSubnet bool) (*machineapi.AWSMachineProviderConfig, error) {
+func provider(in *machineProviderInput) (*machineapi.AWSMachineProviderConfig, error) {
+	tags, err := tagsFromUserTags(in.clusterID, in.userTags)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create machineapi.TagSpecifications from UserTags")
 	}
@@ -88,51 +106,59 @@ func provider(clusterID string, region string, subnet string, instanceType strin
 			APIVersion: "machine.openshift.io/v1beta1",
 			Kind:       "AWSMachineProviderConfig",
 		},
-		InstanceType: instanceType,
+		InstanceType: in.instanceType,
 		BlockDevices: []machineapi.BlockDeviceMappingSpec{
 			{
 				EBS: &machineapi.EBSBlockDeviceSpec{
-					VolumeType: pointer.StringPtr(root.Type),
-					VolumeSize: pointer.Int64Ptr(int64(root.Size)),
-					Iops:       pointer.Int64Ptr(int64(root.IOPS)),
+					VolumeType: pointer.StringPtr(in.root.Type),
+					VolumeSize: pointer.Int64Ptr(int64(in.root.Size)),
+					Iops:       pointer.Int64Ptr(int64(in.root.IOPS)),
 					Encrypted:  pointer.BoolPtr(true),
-					KMSKey:     machineapi.AWSResourceReference{ARN: pointer.StringPtr(root.KMSKeyARN)},
+					KMSKey:     machineapi.AWSResourceReference{ARN: pointer.StringPtr(in.root.KMSKeyARN)},
 				},
 			},
 		},
-		Tags:               tags,
-		IAMInstanceProfile: &machineapi.AWSResourceReference{ID: pointer.StringPtr(fmt.Sprintf("%s-%s-profile", clusterID, role))},
-		UserDataSecret:     &corev1.LocalObjectReference{Name: userDataSecret},
-		CredentialsSecret:  &corev1.LocalObjectReference{Name: "aws-cloud-credentials"},
-		Placement:          machineapi.Placement{Region: region, AvailabilityZone: zone},
+		Tags: tags,
+		IAMInstanceProfile: &machineapi.AWSResourceReference{
+			ID: pointer.StringPtr(fmt.Sprintf("%s-%s-profile", in.clusterID, in.role)),
+		},
+		UserDataSecret:    &corev1.LocalObjectReference{Name: in.userDataSecret},
+		CredentialsSecret: &corev1.LocalObjectReference{Name: "aws-cloud-credentials"},
+		Placement:         machineapi.Placement{Region: in.region, AvailabilityZone: in.zone},
 		SecurityGroups: []machineapi.AWSResourceReference{{
 			Filters: []machineapi.Filter{{
 				Name:   "tag:Name",
-				Values: []string{fmt.Sprintf("%s-%s-sg", clusterID, role)},
+				Values: []string{fmt.Sprintf("%s-%s-sg", in.clusterID, in.role)},
 			}},
 		}},
 	}
 
-	if subnet == "" {
+	subnetName := fmt.Sprintf("%s-private-%s", in.clusterID, in.zone)
+	if !in.privateSubnet {
+		config.PublicIP = pointer.BoolPtr(!in.privateSubnet)
+		subnetName = fmt.Sprintf("%s-public-%s", in.clusterID, in.zone)
+	}
+
+	if in.subnet == "" {
 		config.Subnet.Filters = []machineapi.Filter{{
 			Name:   "tag:Name",
-			Values: []string{fmt.Sprintf("%s-private-%s", clusterID, zone)},
+			Values: []string{subnetName},
 		}}
 	} else {
-		config.Subnet.ID = pointer.StringPtr(subnet)
+		config.Subnet.ID = pointer.StringPtr(in.subnet)
 	}
 
-	if osImage == "" {
+	if in.osImage == "" {
 		config.AMI.Filters = []machineapi.Filter{{
 			Name:   "tag:Name",
-			Values: []string{fmt.Sprintf("%s-ami-%s", clusterID, region)},
+			Values: []string{fmt.Sprintf("%s-ami-%s", in.clusterID, in.region)},
 		}}
 	} else {
-		config.AMI.ID = pointer.StringPtr(osImage)
+		config.AMI.ID = pointer.StringPtr(in.osImage)
 	}
 
-	if imds.Authentication != "" {
-		config.MetadataServiceOptions.Authentication = machineapi.MetadataServiceAuthentication(imds.Authentication)
+	if in.imds.Authentication != "" {
+		config.MetadataServiceOptions.Authentication = machineapi.MetadataServiceAuthentication(in.imds.Authentication)
 	}
 
 	return config, nil

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -14,10 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func isPublicSubnet(subnet string) bool {
-	return true
-}
-
 // MachineSets returns a list of machinesets for a machinepool.
 func MachineSets(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]*machineapi.MachineSet, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -199,7 +199,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			}
 		}
 
-		mpool := defaultAWSMachinePoolPlatform()
+		mpool := defaultAWSMachinePoolPlatform("master")
 
 		osImage := strings.SplitN(string(*rhcosImage), ",", 2)
 		osImageID := osImage[0]

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -302,9 +302,18 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				machineSets = append(machineSets, set)
 			}
 		case awstypes.Name:
+			// here?
 			subnets := map[string]string{}
+
+			fmt.Println(">>>")
+
 			if len(ic.Platform.AWS.Subnets) > 0 {
 				subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
+				fmt.Printf(">>> subnetMeta=%v\n", subnetMeta)
+				if pool.Name == "edge" {
+					subnetMeta, err = installConfig.AWS.EdgeSubnets(ctx)
+					fmt.Printf(">>> subnetMeta=%v\n", subnetMeta)
+				}
 				if err != nil {
 					return err
 				}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -305,14 +305,10 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			// here?
 			subnets := map[string]string{}
 
-			fmt.Println(">>>")
-
 			if len(ic.Platform.AWS.Subnets) > 0 {
 				subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
-				fmt.Printf(">>> subnetMeta=%v\n", subnetMeta)
-				if pool.Name == "edge" {
+				if pool.Name == types.InstallConfigPoolNameEdge {
 					subnetMeta, err = installConfig.AWS.EdgeSubnets(ctx)
-					fmt.Printf(">>> subnetMeta=%v\n", subnetMeta)
 				}
 				if err != nil {
 					return err

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -88,10 +88,17 @@ var (
 	_ asset.WritableAsset = (*Worker)(nil)
 )
 
-func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
+func defaultAWSMachinePoolPlatform(poolName string) awstypes.MachinePool {
+	defaultEBSType := "gp3"
+	// gp3 is not offered in all local-zones locations. Once it is available,
+	// it can be used as default for all machine pools.
+	// https://aws.amazon.com/about-aws/global-infrastructure/localzones/features
+	if poolName == types.InstallConfigPoolNameEdge {
+		defaultEBSType = "gp2"
+	}
 	return awstypes.MachinePool{
 		EC2RootVolume: awstypes.EC2RootVolume{
-			Type: "gp3",
+			Type: defaultEBSType,
 			Size: decimalRootVolumeSize,
 		},
 	}
@@ -184,10 +191,10 @@ func defaultNutanixMachinePoolPlatform() nutanixtypes.MachinePool {
 }
 
 func awsDefaultMachineTypes(region string, arch types.Architecture) []string {
-	classes := awsdefaults.InstanceClasses(region, arch)
-	types := make([]string, len(classes))
-	for i, c := range classes {
-		types[i] = fmt.Sprintf("%s.xlarge", c)
+	dTypes := awsdefaults.InstanceTypes(region, arch)
+	types := make([]string, len(dTypes))
+	for i, t := range dTypes {
+		types[i] = t
 	}
 	return types
 }
@@ -316,7 +323,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				}
 			}
 
-			mpool := defaultAWSMachinePoolPlatform()
+			mpool := defaultAWSMachinePoolPlatform(pool.Name)
 
 			osImage := strings.SplitN(string(*rhcosImage), ",", 2)
 			osImageID := osImage[0]
@@ -342,10 +349,11 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				}
 			}
 			if mpool.InstanceType == "" {
-				mpool.InstanceType, err = aws.PreferredInstanceType(ctx, installConfig.AWS, awsDefaultMachineTypes(installConfig.Config.Platform.AWS.Region, installConfig.Config.ControlPlane.Architecture), mpool.Zones)
+				instanceTypes := awsDefaultMachineTypes(installConfig.Config.Platform.AWS.Region, installConfig.Config.ControlPlane.Architecture)
+				mpool.InstanceType, err = aws.PreferredInstanceType(ctx, installConfig.AWS, instanceTypes, mpool.Zones)
 				if err != nil {
 					logrus.Warn(errors.Wrap(err, "failed to find default instance type"))
-					mpool.InstanceType = awsDefaultMachineTypes(installConfig.Config.Platform.AWS.Region, installConfig.Config.ControlPlane.Architecture)[0]
+					mpool.InstanceType = instanceTypes[0]
 				}
 			}
 			// if the list of zones is the default we need to try to filter the list in case there are some zones where the instance might not be available

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -302,9 +302,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				machineSets = append(machineSets, set)
 			}
 		case awstypes.Name:
-			// here?
 			subnets := map[string]string{}
-
 			if len(ic.Platform.AWS.Subnets) > 0 {
 				subnetMeta, err := installConfig.AWS.PrivateSubnets(ctx)
 				if pool.Name == types.InstallConfigPoolNameEdge {

--- a/pkg/types/aws/availabilityzones.go
+++ b/pkg/types/aws/availabilityzones.go
@@ -1,0 +1,6 @@
+package aws
+
+const (
+	AvailabilityZoneTypeDefault = "availability-zone"
+	AvailabilityZoneTypeLocal   = "local-zone"
+)

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -6,14 +6,14 @@ import (
 )
 
 var (
-	defaultMachineClass = map[types.Architecture]map[string][]string{
+	defaultMachineTypes = map[types.Architecture]map[string][]string{
 		types.ArchitectureAMD64: {
 			// Example region default machine class override for AMD64:
-			// "ap-east-1":      {"m5", "m4"},
+			// "ap-east-1":      {"m6i.xlarge", "m5.xlarge"},
 		},
 		types.ArchitectureARM64: {
 			// Example region default machine class override for ARM64:
-			// "us-east-1":      {"m6g", "m6gd"},
+			// "us-east-1":      {"m6g.xlarge", "m6gd.xlarge"},
 		},
 	}
 )
@@ -22,10 +22,12 @@ var (
 func SetPlatformDefaults(p *aws.Platform) {
 }
 
-// InstanceClasses returns a list of instance "class", in decreasing priority order, which we should use for a given
-// region. Default is m6i then m5 unless a region override is defined in defaultMachineClass.
-func InstanceClasses(region string, arch types.Architecture) []string {
-	if classesForArch, ok := defaultMachineClass[arch]; ok {
+// InstanceTypes returns a list of instance types, in decreasing priority order, which we should use for a given
+// region. Default is m6i.xlarge, m5.xlarge, then lastly c5d.xlarge unless a region override
+// is defined in defaultMachineTypes.
+// c5d.xlarge is included on the list due the common availability for Local Zone offerings.
+func InstanceTypes(region string, arch types.Architecture) []string {
+	if classesForArch, ok := defaultMachineTypes[arch]; ok {
 		if classes, ok := classesForArch[region]; ok {
 			return classes
 		}
@@ -33,8 +35,8 @@ func InstanceClasses(region string, arch types.Architecture) []string {
 
 	switch arch {
 	case types.ArchitectureARM64:
-		return []string{"m6g"}
+		return []string{"m6g.xlarge"}
 	default:
-		return []string{"m6i", "m5"}
+		return []string{"m6i.xlarge", "m5.xlarge", "c5d.2xlarge"}
 	}
 }

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -28,10 +28,13 @@ const (
 	// If you bump this, you must also update the list of convertable values in
 	// pkg/types/conversion/installconfig.go
 	InstallConfigVersion  = "v1"
-	workerMachinePoolName = "worker"
+	machinePoolNameWorker = "worker"
+	machinePoolNameEdge   = "edge"
 )
 
 var (
+	//machinePoolNames = [...]string{"worker", "edge"}
+
 	// PlatformNames is a slice with all the visibly-supported
 	// platform names in alphabetical order. This is the list of
 	// platforms presented to the user in the interactive wizard.
@@ -423,7 +426,11 @@ type Capabilities struct {
 // WorkerMachinePool retrieves the worker MachinePool from InstallConfig.Compute
 func (c *InstallConfig) WorkerMachinePool() *MachinePool {
 	for _, machinePool := range c.Compute {
-		if machinePool.Name == workerMachinePoolName {
+
+		if machinePool.Name == machinePoolNameEdge {
+			return &machinePool
+		}
+		if machinePool.Name == machinePoolNameWorker {
 			return &machinePool
 		}
 	}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -27,14 +27,13 @@ const (
 	// InstallConfigVersion is the version supported by this package.
 	// If you bump this, you must also update the list of convertable values in
 	// pkg/types/conversion/installconfig.go
-	InstallConfigVersion  = "v1"
-	machinePoolNameWorker = "worker"
-	machinePoolNameEdge   = "edge"
+	InstallConfigVersion        = "v1"
+	InstallConfigPoolNameMaster = "master"
+	InstallConfigPoolNameWorker = "worker"
+	InstallConfigPoolNameEdge   = "edge"
 )
 
 var (
-	//machinePoolNames = [...]string{"worker", "edge"}
-
 	// PlatformNames is a slice with all the visibly-supported
 	// platform names in alphabetical order. This is the list of
 	// platforms presented to the user in the interactive wizard.
@@ -426,11 +425,8 @@ type Capabilities struct {
 // WorkerMachinePool retrieves the worker MachinePool from InstallConfig.Compute
 func (c *InstallConfig) WorkerMachinePool() *MachinePool {
 	for _, machinePool := range c.Compute {
-
-		if machinePool.Name == machinePoolNameEdge {
-			return &machinePool
-		}
-		if machinePool.Name == machinePoolNameWorker {
+		switch machinePool.Name {
+		case InstallConfigPoolNameWorker, InstallConfigPoolNameEdge:
 			return &machinePool
 		}
 	}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -472,7 +472,6 @@ func validateCompute(platform *types.Platform, control *types.MachinePool, pools
 		if control != nil && control.Architecture != p.Architecture {
 			allErrs = append(allErrs, field.Invalid(poolFldPath.Child("architecture"), p.Architecture, "heteregeneous multi-arch is not supported; compute pool architecture must match control plane"))
 		}
-
 		allErrs = append(allErrs, ValidateMachinePool(platform, &p, poolFldPath)...)
 	}
 	return allErrs

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -49,12 +49,6 @@ import (
 	"github.com/openshift/installer/pkg/validate"
 )
 
-const (
-	masterPoolName = "master"
-	workerPoolName = "worker"
-	edgePoolName   = "edge"
-)
-
 // list of known plugins that require hostPrefix to be set
 var pluginsUsingHostPrefix = sets.NewString(string(operv1.NetworkTypeOpenShiftSDN), string(operv1.NetworkTypeOVNKubernetes))
 
@@ -430,8 +424,8 @@ func validateClusterNetwork(n *types.Networking, cn *types.ClusterNetworkEntry, 
 
 func validateControlPlane(platform *types.Platform, pool *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if pool.Name != masterPoolName {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("name"), pool.Name, []string{masterPoolName}))
+	if pool.Name != types.InstallConfigPoolNameMaster {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("name"), pool.Name, []string{types.InstallConfigPoolNameMaster}))
 	}
 	if pool.Replicas != nil && *pool.Replicas == 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("replicas"), pool.Replicas, "number of control plane replicas must be positive"))
@@ -457,14 +451,14 @@ func validateComputeEdge(platform *types.Platform, edgePool *types.MachinePool, 
 func validateCompute(platform *types.Platform, control *types.MachinePool, pools []types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	poolNames := map[string]bool{}
-	validCompute := []string{workerPoolName, edgePoolName}
+	validCompute := []string{types.InstallConfigPoolNameWorker, types.InstallConfigPoolNameEdge}
 	for i, p := range pools {
 		poolFldPath := fldPath.Index(i)
 		for _, name := range validCompute {
 			switch name {
-			case workerPoolName:
+			case types.InstallConfigPoolNameWorker:
 				break
-			case edgePoolName:
+			case types.InstallConfigPoolNameEdge:
 				allErrs = append(allErrs, validateComputeEdge(platform, &p, fldPath, poolFldPath)...)
 				break
 			default:

--- a/upi/aws/cloudformation/01.99_net_local-zone.yaml
+++ b/upi/aws/cloudformation/01.99_net_local-zone.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for create Public Local Zone subnets
+
+Parameters:
+  VpcId:
+    Description: VPC Id
+    Type: String
+  ZoneName:
+    Description: Local Zone Name (Example us-west-2-lax-1a)
+    Type: String
+  SubnetName:
+    Description: Local Zone Name (Example cluster-usw2-lax-1a)
+    Type: String
+  PublicRouteTableId:
+    Description: Public Route Table ID to associate the Local Zone subnet
+    Type: String
+  PublicSubnetCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.0.128.0/20
+    Description: CIDR block for Public Subnet
+    Type: String
+
+Resources:
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VpcId
+      CidrBlock: !Ref PublicSubnetCidr
+      AvailabilityZone: !Ref ZoneName
+      Tags:
+      - Key: Name
+        Value: !Ref SubnetName
+      - Key: kubernetes.io/cluster/unmanaged
+        Value: "true"
+
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTableId
+
+Outputs:
+  PublicSubnetIds:
+    Description: Subnet IDs of the public subnets.
+    Value:
+      !Join [
+        "",
+        [!Ref PublicSubnet]
+      ]

--- a/upi/aws/cloudformation/01_vpc.yaml
+++ b/upi/aws/cloudformation/01_vpc.yaml
@@ -286,3 +286,6 @@ Outputs:
         ",",
         [!Ref PrivateSubnet, !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]]
       ]
+  PublicRouteTableId:
+    Description: Public Route table ID
+    Value: !Ref PublicRouteTable


### PR DESCRIPTION
Machine Pool `edge`
- [x] ensure a new machine pool `edge` is created
- [x] ensure only AWS supports `edge` machine pool
- [x] allow  `c5d.2xlarge` instance to the pool (common between locations), and replace the default EBS to and `gp2`
- [x] allow empty machine pool when LZ subnet is added
- [x] allow replace the instance type
- [x] allow replace the EBS type

Local Zone pools:
- [ ] ensure only zone type `local-zone` creates `edge` MachineSet
- [ ] ensure to fail when `wavelength-zone` zone type is added to the subnet list
- [x] ensure the instance type is offered by the zone used to deploy on Local Zones


Documentation:
- [ ] network stack for UPI
- [ ] steps to create the cluster in existing VPC with local zones subnets