### PR TITLE
RFE-2782/phase-1: Set MTU to CNI when edge pool is present on AWS

### DIFF
--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -197,7 +197,7 @@ func (no *Networking) generateDefaultNetworkConfig(defaultNetwork *operatorv1.De
 func (no *Networking) generateDefaultNetworkConfigAWSEdge(ic *installconfig.InstallConfig) ([]byte, bool, error) {
 
 	var (
-		hasEdgePool bool = false
+		hasEdgePool = false
 		defNetCfg   *operatorv1.DefaultNetworkDefinition
 		err         error
 	)


### PR DESCRIPTION
This change introduce to installer generate the CNO manifest file cluster-network-03-config.yml into the cluster manifest path.

The goal is to force the Cluster Network to use MTU according to the network plugin when the AWS Edge machine pool is set. Currently there is support only for AWS Local Zones on edge machine pool. Local Zones limits the MTU for 1300[1] to communicate into the nodes in Availability Zones (regular zones within the region).

On the Phase-0[2] of support of AWS Local Zones, the instructions is added in the documentation[3]. This change is covering the Phase-1[4].

[1] https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html [2] https://issues.redhat.com/browse/SPLAT-635
[3] https://github.com/openshift/openshift-docs/pull/55327 [4] https://issues.redhat.com/browse/SPLAT-636